### PR TITLE
Implement Entity Framework Core workaround

### DIFF
--- a/src/Blog/Blog.csproj
+++ b/src/Blog/Blog.csproj
@@ -1,4 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project InitialTargets="MoveEntityFrameworkCoreTargets">
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk.Web" />
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -13,8 +15,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
   </ItemGroup>
+
+  <!-- Required due to an issue with the dotnet ef CLI tool -->
+  <!-- dotnet ef CLI creates file at $(MSBuildProjectDirectory)/obj/ before executing MSBuild -->
+  <Target Name="MoveEntityFrameworkCoreTargets">
+    <Move Condition="Exists($(EntityFrameworkCoreTargetsFile))"
+      SourceFiles="$(EntityFrameworkCoreTargetsFile)"
+      DestinationFolder="$(BaseIntermediateOutputPath)"
+    />
+    <RemoveDir
+      Directories="$(MSBuildProjectDirectory)/obj/"
+    />
+  </Target>
+
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk.Web" />
 
 </Project>


### PR DESCRIPTION
The Entity Framework Core CLI produces a .targets file in the obj
directory of the project which contains models.  It needs to be placed
in the BaseIntermediateOutput directory with the other props and targets
files produced by MSBuild.